### PR TITLE
MB-2: Correct scaling

### DIFF
--- a/libfractal/fractal.c
+++ b/libfractal/fractal.c
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+#include <stdio.h>
 #include "fractal.h"
 #include "math.h"
 
@@ -44,10 +45,13 @@ layout(location = 0) in vec4 attrib_position;
 layout(location = 0) out vec4 passed_position;
 
 // matrix for transforming fragments into mandelbrot space
-uniform mat4 uniform_projection;
+uniform mat4 uniform_fractal_scale;
 
 void main() {
-    passed_position = inverse(uniform_projection) * attrib_position;
+    // the inverse of the scale matrix is used,
+    // as we take in normalized coordinates
+    // which we want to transform into the mandelbrot space
+    passed_position = inverse(uniform_fractal_scale) * attrib_position;
     gl_Position = attrib_position;
 });
 
@@ -146,10 +150,12 @@ void fractal_pipeline_destroy(fractal_pipeline_t *self) {
     vertex_array_destroy(&self->vertex_array);
 }
 
-void fractal_pipeline_submit(fractal_pipeline_t *self) {
-    f32mat4_t projection;
-    f32mat4_create_orthogonal(&projection, -2.0f, 0.47f, -1.12f, 1.12f);
-    shader_uniform_f32mat4(&self->shader, "uniform_projection", &projection);
+void fractal_pipeline_submit(fractal_pipeline_t *self, u32 width, u32 height) {
+    // Viewport aspect ratio determines scale of fractal
+    f32 ratio = (f32) width / (f32) height;
+    f32mat4_t scale;
+    f32mat4_create_orthogonal(&scale, -2.0f * ratio, 0.47f * ratio, -1.12f, 1.12f);
+    shader_uniform_f32mat4(&self->shader, "uniform_fractal_scale", &scale);
 
     shader_bind(&self->shader);
     vertex_array_bind(&self->vertex_array);

--- a/libfractal/fractal.h
+++ b/libfractal/fractal.h
@@ -52,7 +52,9 @@ void fractal_pipeline_destroy(fractal_pipeline_t *self);
  * Submit the pipeline state to the gpu
  *
  * @param self pipeline handle
+ * @param width viewport width
+ * @param height viewport height
  */
-void fractal_pipeline_submit(fractal_pipeline_t *self);
+void fractal_pipeline_submit(fractal_pipeline_t *self, u32 width, u32 height);
 
 #endif// LIBFRACTAL_FRACTAL_H

--- a/mandelbrot.c
+++ b/mandelbrot.c
@@ -28,14 +28,14 @@
 
 int main(int argc, char **argv) {
     display_t display;
-    display_create(&display, "mandelbrot", 900, 600);
+    display_create(&display, "mandelbrot", 900, 900);
 
     fractal_pipeline_t pipeline;
     fractal_pipeline_create(&pipeline);
 
     while (display_running(&display)) {
         glClear(GL_COLOR_BUFFER_BIT);
-        fractal_pipeline_submit(&pipeline);
+        fractal_pipeline_submit(&pipeline, display.width, display.height);
         display_update_frame(&display);
     }
 


### PR DESCRIPTION
# Correct scaling

Scaling is now based on the window aspect ratio, and is computed by the following formula:

$ratio = width / height$
$scale\\_matrix = ortho(-2.0 * ratio, 0.47 * ratio, -1.12, 1.12)$

# Preview

![image](https://github.com/elias-plank/mandelbrot/assets/45200003/f967cf9e-74b7-406e-8513-eca961a3dfd8)
